### PR TITLE
[AKATSUKI] overlay: SystemUI: Enable statusbar and navbar burn-in protection

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -37,4 +37,13 @@
 
     <!-- Doze: whether the double tap sensor reports 2D touch coordinates -->
     <bool name="doze_double_tap_reports_touch_coordinates">false</bool>
+
+    <!-- Whether to enable shifting of elements in the status bar and the navigation bar.
+         Should be enabled for OLED devices to reduce/prevent burn in on the status bar
+         and on the navigation bar and disabled for all other devices. -->
+    <bool name="config_statusBarBurnInProtection">true</bool>
+
+    <!-- Amount of time in seconds to wait before shifting elements around when the burn-in
+         protection is enabled for status bar and navigation bar -->
+    <integer name="config_shift_interval">45</integer>
 </resources>

--- a/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ * Copyright (c) 2006, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+-->
+<resources>
+    <!-- The maximum offset in either direction that elements are moved vertically to prevent
+         burn-in on status bar and navigation bar. -->
+    <dimen name="vertical_max_shift">1.0dp</dimen>
+
+    <!-- The maximum offset in either direction that elements are moved horizontally to prevent
+         burn-in on status bar and navigation bar. -->
+    <dimen name="horizontal_max_shift">4.0dp</dimen>
+</resources>
+


### PR DESCRIPTION
This enables burn-in protection for status bar and navigation bar:
their elements will be shifted around to reduce or prevent burn-in.