### PR TITLE
[AKATSUKI] overlay: base: Reduce minimum brightness

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -31,6 +31,7 @@
 
          Must be overridden in platform specific overlays -->
     <integer-array name="config_autoBrightnessLevels">
+        <item>32</item>
         <item>64</item>
         <item>128</item>
         <item>170</item>
@@ -50,7 +51,8 @@
          than the size of the config_autoBrightnessLevels array.
          This must be overridden in platform specific overlays -->
     <integer-array name="config_autoBrightnessLcdBacklightValues">
-        <item>10</item>   <!--    0 -->
+        <item>3</item>    <!--    0 -->
+        <item>10</item>   <!--   32 -->
         <item>32</item>   <!--   64 -->
         <item>64</item>   <!--  128 -->
         <item>80</item>   <!--  170 -->
@@ -67,12 +69,12 @@
 
     <!-- Minimum screen brightness setting allowed by the power manager.
          The user is forbidden from setting the brightness below this level. -->
-    <integer name="config_screenBrightnessSettingMinimum">10</integer>
+    <integer name="config_screenBrightnessSettingMinimum">2</integer>
 
     <!-- Screen brightness used to dim the screen while dozing in a very low power state.
          May be less than the minimum allowed brightness setting
          that can be set by the user. -->
-    <integer name="config_screenBrightnessDoze">5</integer>
+    <integer name="config_screenBrightnessDoze">1</integer>
 
     <!-- Enable doze mode
          ComponentName of a dream to show whenever the system would otherwise have gone to sleep. -->
@@ -106,7 +108,7 @@
          some range of adjustment to dim the screen further than usual in very
          dark rooms. The contents of the screen must still be clearly visible
          in darkness (although they may not be visible in a bright room). -->
-    <integer name="config_screenBrightnessDark">5</integer>
+    <integer name="config_screenBrightnessDark">2</integer>
 
     <!-- Whether device supports double tap to wake -->
     <bool name="config_supportDoubleTapWake">false</bool>


### PR DESCRIPTION
The values are getting shifted, hence to get the minimum values
that should be currently allowed, we need to address a quirk by
actually feeding lower value to the Lights HAL in order to satisfy
the calculation requirements.

Reduce the minimum brightness so that the Lights HAL will write
a minimum brightness of "4" for AOD and "8" for BrightnessDark
manual adjustment (when auto-brightness is off).

As minimum auto-brightness value, add a new entry that will
automatically set a brightness of "12" if the ALS reads very dark.