### PR TITLE
[master] BoardConfig: Remove NXP_CHIP_TYPE flag

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -28,7 +28,6 @@ endif
 PRODUCT_PLATFORM := tama
 
 # NFC
-NXP_CHIP_TYPE := PN553
 NXP_CHIP_FW_TYPE := PN553
 
 BOARD_KERNEL_CMDLINE += androidboot.hardware=akatsuki


### PR DESCRIPTION
This flag no longer exist in Android P.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>