### PR TITLE
[WIP] h9436.mk: Prefix persist.vendor to radio props

### DIFF
--- a/aosp_h9436.mk
+++ b/aosp_h9436.mk
@@ -16,8 +16,7 @@
 PRODUCT_DEVICE_DS := true
 
 PRODUCT_PROPERTY_OVERRIDES += \
-    persist.multisim.config=dsds \
-    persist.radio.multisim.config=dsds \
+    persist.vendor.radio.multisim.config=dsds \
     ro.telephony.default_network=9,9 \
     persist.vendor.radio.block_allow_data=0
 


### PR DESCRIPTION
This is needed since whitelisted "compatible" properties must begin with either `vendor` or `persist.vendor`, see [system/core/init/stable_properties.h](https://android.googlesource.com/platform/system/core/+/20ac1203a3201ac3e6d05a19325f5569033f3d08/init/stable_properties.h#26).

Also get rid of `persist.multisim.config` since it is no longer used anywhere.