### PR TITLE
[Akatsuki] BoardConfig: Remove duplicate KEYMASTER_V4 definition.

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -27,9 +27,6 @@ endif
 # Platform
 PRODUCT_PLATFORM := tama
 
-# Keymaster 4
-TARGET_KEYMASTER_V4 := true
-
 # NFC
 NXP_CHIP_FW_TYPE := PN553
 


### PR DESCRIPTION
This variable is already defined earlier in device.mk, which is
important to get picked up by other makefiles in common. The makefile in
this file (BoardConfig.mk) is both duplicate and too late, thus remove
it.

See https://github.com/sonyxperiadev/device-sony-ganges/pull/2 for a similar issue.