### PR TITLE
Fix the wrong battery capacity

### DIFF
--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -132,7 +132,7 @@
         <value>4</value>
     </array>
     <item name="cpu.awake">27.46</item>
-    <item name="battery.capacity">3060</item>
+    <item name="battery.capacity">3330</item>
     <item name="wifi.controller.idle">0.00</item>
     <item name="wifi.controller.rx">5.55</item>
     <item name="wifi.controller.tx">6.70</item>


### PR DESCRIPTION
According to the [specifications](https://www.sonymobile.com/global-en/products/phones/xperia-xz3/specifications/) the capacity is 3330 and not 3060.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonyxperiadev/device-sony-akatsuki/15)
<!-- Reviewable:end -->
