### PR TITLE
overlay: SystemUI: dimens: Increase status bar padding

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
@@ -23,5 +23,11 @@
     <!-- The maximum offset in either direction that elements are moved horizontally to prevent
          burn-in on status bar and navigation bar. -->
     <dimen name="horizontal_max_shift">4.0dp</dimen>
+
+    <!-- the padding on the start of the statusbar -->
+    <dimen name="status_bar_padding_start">12dp</dimen>
+
+    <!-- the padding on the end of the statusbar -->
+    <dimen name="status_bar_padding_end">12dp</dimen>
 </resources>
 


### PR DESCRIPTION
I accidentally built and flashed Akatsuki without local modifications... and noticed this by seeing part of the status bar magically hidden behind the rounded corners. Turns out I never actually submitted this and some people might have been running around with occluded text for years :see_no_evil: 

---

The text in the status bar comes very close to the rounded edges of the
display on lower font sizes, and is sometimes even partially occluded by
it.  Move text inwards by increasing padding slightly and prevent this
issue.