### PR TITLE
[AKATSUKI] mixer_paths: Fix microphone low capture volume

### DIFF
--- a/rootdir/vendor/etc/mixer_paths.xml
+++ b/rootdir/vendor/etc/mixer_paths.xml
@@ -344,8 +344,8 @@
     <ctl name="DEC4 Volume" value="84" />
     <ctl name="DEC5 Volume" value="84" />
     <ctl name="DEC6 Volume" value="84" />
-    <ctl name="DEC7 Volume" value="84" />
-    <ctl name="DEC8 Volume" value="84" />
+    <ctl name="DEC7 Volume" value="94" />
+    <ctl name="DEC8 Volume" value="94" />
 
     <!-- Compander controls -->
     <ctl name="COMP1 Switch" value="1" />
@@ -1797,12 +1797,12 @@
 
     <!-- Gain offset target for dmic1 unit calibration -->
     <path name="dmic1-adj-gain">
-        <ctl name="DEC7 Volume" value="94" />
+        <ctl name="DEC7 Volume" value="114" />
     </path>
 
     <!-- Gain offset target for dmic2 unit calibration -->
     <path name="dmic2-adj-gain">
-        <ctl name="DEC8 Volume" value="94" />
+        <ctl name="DEC8 Volume" value="104" />
     </path>
 
     <!-- For Tavil, DMIC numbered from 0 to 5 -->
@@ -2049,8 +2049,8 @@
 
     <path name="stereo-mic">
         <path name="stereo-mic-common" />
-        <ctl name="DEC8 Volume" value="86" />
-        <ctl name="DEC7 Volume" value="90" />
+        <ctl name="DEC8 Volume" value="96" />
+        <ctl name="DEC7 Volume" value="100" />
     </path>
 
     <path name="speaker-mono-mic-common">
@@ -2060,7 +2060,7 @@
 
     <path name="speaker-mono-mic">
         <path name="speaker-mono-mic-common" />
-        <ctl name="DEC7 Volume" value="92" />
+        <ctl name="DEC7 Volume" value="102" />
     </path>
 
     <path name="speaker-protected">
@@ -2222,8 +2222,8 @@
 
     <path name="headset-mic">
         <path name="amic2" />
-        <ctl name="DEC0 Volume" value="84" />
-        <ctl name="ADC2 Volume" value="11" />
+        <ctl name="DEC0 Volume" value="110" />
+        <ctl name="ADC2 Volume" value="19" />
     </path>
 
     <path name="headset-mic-asr">
@@ -2421,14 +2421,14 @@
 
     <path name="voice-rec-mic">
         <path name="camcorder-mic-common" />
-        <ctl name="DEC8 Volume" value="86" />
-        <ctl name="DEC7 Volume" value="90" />
+        <ctl name="DEC8 Volume" value="96" />
+        <ctl name="DEC7 Volume" value="100" />
     </path>
 
     <path name="camcorder-mic">
         <path name="camcorder-mic-common" />
-        <ctl name="DEC8 Volume" value="86" />
-        <ctl name="DEC7 Volume" value="90" />
+        <ctl name="DEC8 Volume" value="96" />
+        <ctl name="DEC7 Volume" value="100" />
     </path>
 
     <path name="bt-sco-headset">
@@ -2495,7 +2495,7 @@
         <ctl name="ADC MUX7" value="AMIC" />
         <ctl name="AMIC MUX7" value="ADC4" />
         <!-- 67 % of 124 (range 0 - 124) Register: 0x221 -->
-        <ctl name="DEC7 Volume" value="83" />
+        <ctl name="DEC7 Volume" value="93" />
         <!-- 47 % of 19 (rounded) register: 0x169 -->
         <ctl name="ADC4 Volume" value="6" />
         <!-- SLIM TX8 records for right channel -->


### PR DESCRIPTION
The microphone volume was very low and the other end could
only barely hear. Now it's fine :)))

P.S.: Should this be ported on all Tama devices?