### PR TITLE
[AKATSUKI] mixer_paths: Add VoIP echo reference paths

### DIFF
--- a/rootdir/vendor/etc/mixer_paths.xml
+++ b/rootdir/vendor/etc/mixer_paths.xml
@@ -587,6 +587,27 @@
         <ctl name="AUDIO_REF_EC_UL1 MUX" value="SLIM_6_RX" />
     </path>
 
+    <path name="echo-reference headset">
+        <path name="echo-reference headphones" />
+    </path>
+
+    <path name="echo-reference-voip">
+        <ctl name="AUDIO_REF_EC_UL10 MUX" value="SLIM_RX" />
+    </path>
+
+    <path name="echo-reference-voip headphones">
+        <ctl name="AUDIO_REF_EC_UL10 MUX" value="SLIM_6_RX" />
+    </path>
+
+    <path name="echo-reference-voip headset">
+        <path name="echo-reference-voip headphones" />
+    </path>
+
+    <path name="echo-reference-voip display-port">
+        <ctl name="AUDIO_REF_EC_UL10 MUX" value="DISPLAY_PORT" />
+    </path>
+
+
     <path name="echo-reference headphones-44.1">
     </path>
 


### PR DESCRIPTION
DSP expects echo reference on UL10 MUX in both VoIP and other usecases on SDM845.
QCOM HAL will request echo-reference-voip and not echo-reference during a VoIP call,
which includes video-conferencing on popular Android apps.


Please replicate this commit on all Tama devices.
Tested with Google Meet on SoMC SDM845 Tama Akatsuki RoW.