### PR TITLE
[master] Switch to PN553 and QTI Haptics drivers

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -21,6 +21,9 @@ DEVICE_PACKAGE_OVERLAYS += \
 # Keymaster 4
 TARGET_KEYMASTER_V4 := true
 
+# Vibrator
+TARGET_VIBRATOR_V1_2 := true
+
 # Device Specific Permissions
 PRODUCT_COPY_FILES := \
     frameworks/native/data/etc/handheld_core_hardware.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/handheld_core_hardware.xml \

--- a/rootdir/vendor/etc/libnfc-nxp.conf
+++ b/rootdir/vendor/etc/libnfc-nxp.conf
@@ -20,7 +20,7 @@ NFC_DEBUG_ENABLED=0
 
 ###############################################################################
 # Nfc Device Node name
-NXP_NFC_DEV_NODE="/dev/pn54x"
+NXP_NFC_DEV_NODE="/dev/pn553"
 
 ###############################################################################
 # Extension for Mifare reader enable


### PR DESCRIPTION
1. Akatsuki device uses PN553 NFC chip and can work with PN553 driver
accordingly without any problems. Switch to this driver.

2. Starting with 4.19 kernel Akatsuki device uses QTI Haptics driver
and should use QTI vibrator HAL accordingly.